### PR TITLE
Comply with new mjml http API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For an elaborate discussion see: https://github.com/mjmlio/mjml/issues/340
 #### Usage
 
 ```
-docker run -p 15500:15500 danihodovic/mjml-http-server
+docker run -p 15500:15500 danihodovic/mjml-server
 ```
 
 ```

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,35 @@ const packageJson = require('../package.json');
 
 const renderEndpoint = '/v1/render';
 
+function handleRequest (req, res) {
+  let mjmlText;
+
+  try {
+    mjmlText = JSON.parse(req.body).mjml;
+  } catch (err) {
+    mjmlText = req.body;
+  }
+
+  let result;
+  try {
+    result = mjml(mjmlText, req.app.get('mjmlConfig'));
+  } catch (err) {
+    logger.error(err);
+    res.statusCode = 400;
+    res.send({ message: 'Failed to compile mjml', ...err });
+    return;
+  }
+
+  const { html, errors } = result;
+
+  res.send({
+    html,
+    mjml: mjmlText,
+    mjml_version: packageJson.dependencies.mjml,
+    errors
+  });
+}
+
 module.exports.create = (argv) => {
   const config = {
     keepComments: argv.keepComments,
@@ -18,31 +47,13 @@ module.exports.create = (argv) => {
   logger.info('Using configuration:', config);
 
   const app = express();
+  app.set('mjmlConfig', config);
   app.use(loggingMiddleware);
   app.use(bodyParser.text({
     type: () => true,
     limit: argv.maxBody
   }));
-  app.post(renderEndpoint, (req, res) => {
-    let html, errors;
-
-    try {
-      const result = mjml(req.body, config);
-      ({ html, errors } = result);
-    } catch (err) {
-      logger.error(err);
-      res.statusCode = 400;
-      res.send({ message: 'Failed to compile mjml', ...err });
-      return;
-    }
-
-    res.send({
-      html,
-      mjml: req.body,
-      mjml_version: packageJson.dependencies.mjml,
-      errors
-    });
-  });
+  app.post(renderEndpoint, handleRequest);
   app.use((req, res) => {
     res.status(404).send({ message: `You're probably looking for ${renderEndpoint}` });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -50,7 +50,9 @@ describe('server', function () {
     expect(res.data).to.eql({ message: "You're probably looking for /v1/render" });
   });
 
-  it('parses requests without a content-type', async () => {
+  // The old API did not pass a json object containing the key mjml. The entire
+  // payload was a mjml document.
+  it('is backwards compatible with the old API', async () => {
     const res = await axios({
       method: 'POST',
       url: url + '/v1/render',
@@ -89,7 +91,7 @@ const makeReq = (url, { method = 'POST', path = '/v1/render', data = '' } = {}) 
   return axios({
     method: 'POST',
     url: url + path,
-    data,
+    data: { mjml: data },
     validateStatus: false
   });
 };


### PR DESCRIPTION
https://mjml.io/api/documentation/ has changed the API. The body is no
longer an mjml text string, but a nested JSON document with the mjml key
containing the actual mjml.

Update the code to work with both types of requests to ensure we don't
break backwards compatibility.