### PR TITLE
Support basic auth

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const mjml = require('mjml');
+const basicAuth = require('express-basic-auth');
 
 const { logger, middleware: loggingMiddleware } = require('./logging.js');
 const packageJson = require('../package.json');
@@ -37,6 +38,7 @@ function handleRequest (req, res) {
 }
 
 module.exports.create = (argv) => {
+  const { BASIC_AUTH_USERS } = process.env;
   const config = {
     keepComments: argv.keepComments,
     beautify: argv.beautify,
@@ -47,6 +49,10 @@ module.exports.create = (argv) => {
   logger.info('Using configuration:', config);
 
   const app = express();
+  if (BASIC_AUTH_USERS) {
+    app.use(basicAuth({ users: JSON.parse(BASIC_AUTH_USERS) }));
+  }
+
   app.set('mjmlConfig', config);
   app.use(loggingMiddleware);
   app.use(bodyParser.text({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "mjml-http-server",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mjml-http-server",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
+        "express-basic-auth": "^1.2.1",
         "express-winston": "^4.0.2",
         "install": "^0.13.0",
         "mjml": "^4.12.0",
@@ -441,6 +442,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1595,6 +1612,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-basic-auth": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
+      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
+      "dependencies": {
+        "basic-auth": "^2.0.1"
       }
     },
     "node_modules/express-winston": {
@@ -4968,6 +4993,21 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -5846,6 +5886,14 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "express-basic-auth": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
+      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
+      "requires": {
+        "basic-auth": "^2.0.1"
       }
     },
     "express-winston": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "express-basic-auth": "^1.2.1",
     "express-winston": "^4.0.2",
     "install": "^0.13.0",
     "mjml": "^4.12.0",


### PR DESCRIPTION
Basic auth is supported via environment variables.
You can now define users in a stringified json following the syntax of the package `express-basic-auth`. For example, if setting the environment variable as `{"user": "password"}` will require to use basic auth user username `user` and password `password`