### PR TITLE
Added the mjml-msobutton component into the Docker image

### DIFF
--- a/.mjmlconfig
+++ b/.mjmlconfig
@@ -1,0 +1,5 @@
+{
+  "packages": [
+    "mjml-msobutton/lib/index.js"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ X-Powered-By: Express
 
 A list of available configuration options can be found in
 [./lib/parse_args.js](./lib/parse_args.js).
+
+#### Plugins
+
+This server includes following community components:
+* [mjml-msobutton](https://github.com/adrien-zinger/mjml-mso-button) - allows you to create buttons that will be correctly rendered in MS Outlook

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mjml-http-server",
-  "version": "0.0.3",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mjml-http-server",
-      "version": "0.0.3",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -14,6 +14,7 @@
         "express-winston": "^4.0.2",
         "install": "^0.13.0",
         "mjml": "^4.12.0",
+        "mjml-msobutton": "^v1.1.0",
         "node-graceful": "^3.0.0",
         "winston": "^3.5.1",
         "yargs": "^16.0.3"
@@ -2905,6 +2906,16 @@
       },
       "bin": {
         "migrate": "lib/cli.js"
+      }
+    },
+    "node_modules/mjml-msobutton": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mjml-msobutton/-/mjml-msobutton-1.1.0.tgz",
+      "integrity": "sha512-VDhX4jXno60Lp2UqMSBVd1MWectea6AAZFdQfPi9qyYsKq8czXiLKSbUVwhkMdKIi2/iWtF+E+9u72ZB2VNC2A==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "mjml": "^4.9.3",
+        "mjml-core": "^4.9.3"
       }
     },
     "node_modules/mjml-navbar": {
@@ -6853,6 +6864,16 @@
         "mjml-core": "4.12.0",
         "mjml-parser-xml": "4.12.0",
         "yargs": "^16.1.0"
+      }
+    },
+    "mjml-msobutton": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mjml-msobutton/-/mjml-msobutton-1.1.0.tgz",
+      "integrity": "sha512-VDhX4jXno60Lp2UqMSBVd1MWectea6AAZFdQfPi9qyYsKq8czXiLKSbUVwhkMdKIi2/iWtF+E+9u72ZB2VNC2A==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "mjml": "^4.9.3",
+        "mjml-core": "^4.9.3"
       }
     },
     "mjml-navbar": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mjml-http-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Dockerized mjml http server from https://github.com/shyim/mjml-server",
   "main": "index.js",
   "scripts": {
@@ -31,6 +31,7 @@
     "express-winston": "^4.0.2",
     "install": "^0.13.0",
     "mjml": "^4.12.0",
+    "mjml-msobutton": "^v1.1.0",
     "node-graceful": "^3.0.0",
     "winston": "^3.5.1",
     "yargs": "^16.0.3"


### PR DESCRIPTION
Hello!

Am I right that [this docker image](https://hub.docker.com/r/danihodovic/mjml-server) is based on this repository?

If so, may I ask you to accept proposed changes to add [mjml-msobutton](https://github.com/adrien-zinger/mjml-mso-button) community component into the server image?  
Previously [I proposed several fixes](https://github.com/adrien-zinger/mjml-mso-button/pulls?q=is%3Apr+is%3Aclosed) to this component and they have been merged by original author - now this component reliably creates buttons that will be displayed correctly in MS Outlook. I thoroughly tested it and fixed everything that worked badly.

This change is fully backwards compatible - it just adds possibility to use `<mj-msobutton>` tag that acts as usual `<mj-button>` tag but generates more code to provide button compatibility.